### PR TITLE
use sr namespace instead of window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+var srns = require('streamrail-namespace');
+
+var SRNS = srns();
+
 var LOGGLY_INPUT_PREFIX = 'http' + (('https:' === document.location.protocol ? 's' : '')) + '://',
     LOGGLY_COLLECTOR_DOMAIN = 'logs-01.loggly.com',
     LOGGLY_SESSION_KEY = 'logglytrackingsession',
@@ -142,7 +146,7 @@ SRLogglyTracker.prototype = {
     }
 };
 
-var existing = window._SRLTracker;
+var existing = SRNS._SRLTracker;
 
 var tracker = new SRLogglyTracker();
 
@@ -154,6 +158,6 @@ if (existing && existing.length) {
     }
 }
 
-window._SRLTracker = tracker; // default global tracker
+SRNS._SRLTracker = tracker; // default global tracker
 
-module.exports = window.SRLogglyTracker = SRLogglyTracker; // if others want to instantiate more than one tracker
+module.exports = SRLogglyTracker; // if others want to instantiate more than one tracker

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git://github.com/streamrail/loggly-browserify.git"
   },
+  "dependencies": {
+    "streamrail-namespace": "git+ssh://git@github.com:streamrail/streamrail-namespace.git"
+  },
   "author": "orcaman",
   "license": "MIT"
 }


### PR DESCRIPTION
- streamrail-namespace is the new module for common namespace (window.SR_NS)
- saving _SRLTracker on the namespace instead of the window
- removing SRLogglyTracker from the window